### PR TITLE
Final Clean-up, Get-in-touch, and Gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
 		"@types/nodemailer": "^6.4.17",
 		"@types/sanitize-html": "^2.16.0",
 		"sass-embedded": "^1.87.0"
-	}
+	},
+	"packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }

--- a/src/components/elements/footer/Footer.astro
+++ b/src/components/elements/footer/Footer.astro
@@ -24,7 +24,7 @@ import SlidingBox from './SlidingBox.astro';
 					class="flex h-full flex-row items-start justify-start gap-10 text-xl lg:flex-col lg:gap-2 xl:flex-row xl:gap-16 xl:text-2xl"
 				>
 					<div class="flex flex-col items-start justify-start gap-2">
-						<a class="cursor-not-allowed font-normal">Kelowna</a>
+						<a class="font-normal" href="#">Gallery</a>
 						<a class="font-normal" href="/team">Our Team</a>
 						<a class="font-normal" href="/funding"
 							>Sponsors & Funding</a

--- a/src/components/elements/navigation/NormalDropdownMenu.astro
+++ b/src/components/elements/navigation/NormalDropdownMenu.astro
@@ -36,6 +36,11 @@ import NavigationOption from '@src/components/elements/navigation/NavigationOpti
 				href="/team"
 				forceNextColumn={true}
 			/>
+			<NavigationOption
+				title="Gallery"
+				description="See photos from the conference"
+				href="#"
+			/>
 		</div>
 	</div>
 </div>

--- a/src/components/elements/navigation/mobile/Overlay.astro
+++ b/src/components/elements/navigation/mobile/Overlay.astro
@@ -37,6 +37,11 @@ import NavigationOption from '@src/components/elements/navigation/NavigationOpti
 				description="Support options and our generous sponsors"
 				href="/funding"
 			/>
+			<NavigationOption
+				title="Gallery"
+				description="See photos from the conference"
+				href="#"
+			/>
 		</div>
 		<div class="sticky bottom-2 flex w-full flex-row gap-2 bg-white p-2">
 			<a

--- a/src/components/sections/conference/GetInTouch.astro
+++ b/src/components/sections/conference/GetInTouch.astro
@@ -8,17 +8,20 @@ import GeneralContactForm from '@src/components/sections/conference/elements/Gen
 >
 	<section id="conference-get-in-touch" class="grid grid-cols-1 gap-4">
 		<div class="flex flex-col gap-6">
-			<h2 class="xs:text-7xl text-6xl font-medium">Get in touch</h2>
+			<h2 class="xs:text-7xl text-6xl font-medium">
+				Get in touch (Post-Conference)
+			</h2>
 			<p class="m-0 p-0 text-2xl leading-relaxed">
-				Have any questions regarding any aspect of the conference? We’re
-				here to help.
+				Got questions about the conference? We're happy to help! Future
+				WCUCC conference organizers are also welcome to reach out to us
+				directly.
 			</p>
 			<p
 				class="m-0 p-0 text-2xl leading-none text-[#78c568] hover:text-[#6CB15E]"
 			>
 				<i class="ri-send-plane-fill"></i>
 				<a
-					href="mailto:wcucc2025@gmail.com"
+					href="mailto:svans@student.ubc.ca"
 					class="underline"
 					style="text-decoration: none;">Shoot us an email</a
 				>


### PR DESCRIPTION
This is the final clean up for the conference website. The Get in touch link was also updated to reflect the post-conference contact information. Placeholder links for the gallery page were created for both the navigation bar and the mobile overlay.